### PR TITLE
Add storage facility to webhook token property

### DIFF
--- a/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
+++ b/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
@@ -21,8 +21,12 @@ import com.dtolabs.rundeck.core.plugins.Plugin;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope;
 import com.dtolabs.rundeck.plugins.descriptions.PluginDescription;
 import com.dtolabs.rundeck.plugins.descriptions.PluginProperty;
+import com.dtolabs.rundeck.plugins.descriptions.RenderingOptions;
+import com.dtolabs.rundeck.plugins.descriptions.RenderingOption;
 import com.dtolabs.rundeck.plugins.notification.NotificationPlugin;
 import com.dtolabs.rundeck.plugins.descriptions.Password;
+
+import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.SELECTION_ACCESSOR_KEY;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -74,6 +78,11 @@ public class SlackNotificationPlugin implements NotificationPlugin {
     @PluginProperty(title = "WebHook Token",
                     description = "WebHook Token, like T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
                     scope=PropertyScope.Instance)
+    @RenderingOptions(
+            {
+                    @RenderingOption(key = SELECTION_ACCESSOR_KEY, value = "STORAGE_PATH"),
+            }
+    )
     private String webhook_token;
 
     @PluginProperty(title = "Slack Channel",

--- a/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
+++ b/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
@@ -27,6 +27,9 @@ import com.dtolabs.rundeck.plugins.notification.NotificationPlugin;
 import com.dtolabs.rundeck.plugins.descriptions.Password;
 
 import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.SELECTION_ACCESSOR_KEY;
+import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.STORAGE_PATH_ROOT_KEY;
+import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.STORAGE_FILE_META_FILTER_KEY;
+import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.VALUE_CONVERSION_KEY;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -81,6 +84,9 @@ public class SlackNotificationPlugin implements NotificationPlugin {
     @RenderingOptions(
             {
                     @RenderingOption(key = SELECTION_ACCESSOR_KEY, value = "STORAGE_PATH"),
+                    @RenderingOption(key = STORAGE_PATH_ROOT_KEY, value = "keys"),
+                    @RenderingOption(key = STORAGE_FILE_META_FILTER_KEY, value = "Rundeck-data-type=password"),
+                    @RenderingOption(key = VALUE_CONVERSION_KEY, value = "STORAGE_PATH_AUTOMATIC_READ"),
             }
     )
     private String webhook_token;


### PR DESCRIPTION
This commit allows the Slack plugin to use the embedded Rundeck Key-Value storage as an option for the Webhook Token property.