### PR TITLE
Fix escaping in slack message

### DIFF
--- a/src/main/resources/templates/slack-incoming-message.ftl
+++ b/src/main/resources/templates/slack-incoming-message.ftl
@@ -48,7 +48,7 @@
             },
             {
                "title":"Options",
-               "value":"${(executionData.argstring?replace('"', '\''))!"N/A"}",
+               "value":"${(executionData.argstring?replace('"', '\"'))!"N/A"}",
                "short":true
             },
             {


### PR DESCRIPTION
This probably should be using some kind of JSON encoder to work around edge cases. I believe this should fix this plugin for any jobs using `\"` in the input parameters.