### PR TITLE
RUN-3601: CVE-2025-48924 Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,18 @@ dependencies {
     implementation(libs.rundeckCore) {
         exclude(group: "com.jcraft")
     }
+    
+    // Add secure commons-lang3 to provide alternative to vulnerable commons-lang 2.6
+    implementation(libs.commonsLang3)
+}
+
+configurations.all {
+    resolutionStrategy {
+        // Replace vulnerable commons-lang with secure commons-lang3
+        dependencySubstitution {
+            substitute module('commons-lang:commons-lang') using module("org.apache.commons:commons-lang3:${libs.versions.commonsLang3.get()}")
+        }
+    }
 }
 
 // task to copy plugin libs to output/lib dir

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,13 @@ nexusPublish = "2.0.0"
 freemarker = "2.3.34"
 rundeckCore = "5.14.0-rc1-20250722"
 axionRelease = "1.18.16"
+# Security overrides for transitive dependencies
+commonsLang3 = "3.18.0"
 
 [libraries]
 freemarker = { group = "org.freemarker", name = "freemarker", version.ref = "freemarker" }
 rundeckCore = { group = "org.rundeck", name = "rundeck-core", version.ref = "rundeckCore" }
+commonsLang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
 
 [plugins]
 axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }


### PR DESCRIPTION
Mitigates CVE-2025-48924 by upgrading commons-lang to commons-lang3 3.18.0.

**Changes:**
- Added commons-lang3 3.18.0 dependency to libs.versions.toml
- Configured dependency substitution to replace vulnerable commons-lang with secure commons-lang3
- Ensures all transitive dependencies use the secure version

**Security Impact:**
This change addresses the security vulnerability identified in CVE-2025-48924 by replacing the vulnerable commons-lang 2.x library with the secure commons-lang3 3.18.0 version.